### PR TITLE
Round score policies

### DIFF
--- a/src/app/(game)/[id]/components/bottom-pane/question/question-active/matching/MatchingBottomPane.js
+++ b/src/app/(game)/[id]/components/bottom-pane/question/question-active/matching/MatchingBottomPane.js
@@ -85,7 +85,7 @@ function MatchingPlayerQuestionController({ lang = DEFAULT_LOCALE }) {
 
     return isCanceled ?
         <span className='2xl:text-3xl text-red-500'>🙅 {MAX_TRIES_EXCEEDED_TEXT[lang]} ({maxMistakes})</span> :
-        <span className='2xl:text-3xl'>Tu peux faire encore <span className='font-bold text-red-500'>{remainingMistakes} erreur{remainingMistakes > 1 && 's'}.</span></span>
+        <span className='2xl:text-3xl'>Tu peux faire encore <span className='font-bold text-red-500'>{remainingMistakes} erreur{remainingMistakes > 1 && 's'}</span>.</span>
     return
 
 }

--- a/src/app/(game)/[id]/components/bottom-pane/question/question-active/matching/MatchingBottomPane.js
+++ b/src/app/(game)/[id]/components/bottom-pane/question/question-active/matching/MatchingBottomPane.js
@@ -1,15 +1,21 @@
-import { useRoleContext } from '@/app/(game)/contexts'
+import { useGameContext, useRoleContext, useTeamContext } from '@/app/(game)/contexts'
 
 import { useParams } from 'next/navigation'
 
 import { GAMES_COLLECTION_REF } from '@/lib/firebase/firestore'
-import { doc } from 'firebase/firestore'
-import { useDocumentData } from 'react-firebase-hooks/firestore'
+import { doc, collection } from 'firebase/firestore'
+import { useDocumentData, useDocumentDataOnce, useCollection } from 'react-firebase-hooks/firestore'
 
-import GameChooserOrder from '@/app/(game)/[id]/components/GameChooserOrder'
 import { GameChooserHelperText } from '@/app/(game)/[id]/components/GameChooserTeamAnnouncement';
 import ResetQuestionButton from '@/app/(game)/[id]/components/bottom-pane/question/question-active/ResetQuestionButton'
 import EndQuestionButton from '@/app/(game)/[id]/components/bottom-pane/question/question-active/EndQuestionButton'
+
+import { DEFAULT_LOCALE } from '@/lib/utils/locales'
+import { MATCHING_MAX_NUM_MISTAKES, matchingTeamIsCanceled } from '@/lib/utils/question/matching'
+
+import { CircularProgress } from '@mui/material'
+
+import clsx from 'clsx'
 
 export default function MatchingBottomPane({ }) {
     const { id: gameId } = useParams()
@@ -31,7 +37,7 @@ export default function MatchingBottomPane({ }) {
                 <MatchingController gameStates={gameStates} />
             </div>
             <div className='basis-1/4'>
-                <GameChooserOrder gameStates={gameStates} />
+                <MatchingRunningOrder gameStates={gameStates} />
             </div>
         </div>
     )
@@ -46,9 +52,47 @@ function MatchingController({ gameStates }) {
     return (
         <div className='flex flex-col h-full w-full items-center justify-around'>
             <span className='2xl:text-4xl font-bold'><GameChooserHelperText chooserTeamId={chooserTeamId} /></span>
+            {myRole === 'player' && <MatchingPlayerQuestionController />}
             {myRole === 'organizer' && <MatchingOrganizerQuestionController />}
         </div>
     )
+}
+
+function MatchingPlayerQuestionController({ lang = DEFAULT_LOCALE }) {
+    const game = useGameContext()
+    const myTeam = useTeamContext()
+
+
+    const [round, roundLoading, roundError] = useDocumentDataOnce(doc(GAMES_COLLECTION_REF, game.id, 'rounds', game.currentRound))
+    const [realtime, realtimeLoading, realtimeError] = useDocumentData(doc(GAMES_COLLECTION_REF, game.id, 'rounds', game.currentRound, 'questions', game.currentQuestion))
+    if (roundError) {
+        return <p><strong>Error: {JSON.stringify(roundError)}</strong></p>
+    }
+    if (realtimeError) {
+        return <p><strong>Error: {JSON.stringify(realtimeError)}</strong></p>
+    }
+    if (roundLoading || realtimeLoading) {
+        return <CircularProgress />
+    }
+    if (!round || !realtime) {
+        return <></>
+    }
+    const { teamNumMistakes } = realtime
+    const remainingMistakes = round.maxMistakes - (teamNumMistakes[myTeam] || 0)
+    const maxMistakes = round.maxMistakes || MATCHING_MAX_NUM_MISTAKES
+
+    const isCanceled = matchingTeamIsCanceled(myTeam, teamNumMistakes, maxMistakes)
+
+    return isCanceled ?
+        <span className='2xl:text-3xl text-red-500'>🙅 {MAX_TRIES_EXCEEDED_TEXT[lang]} ({maxMistakes})</span> :
+        <span className='2xl:text-3xl'>Tu peux faire encore <span className='font-bold text-red-500'>{remainingMistakes} erreur{remainingMistakes > 1 && 's'}.</span></span>
+    return
+
+}
+
+const MAX_TRIES_EXCEEDED_TEXT = {
+    'en': "You have exceeded the maximum number of mistakes!",
+    'fr-FR': "Tu as excédé le nombre maximum d'erreurs!"
 }
 
 function MatchingOrganizerQuestionController({ }) {
@@ -58,4 +102,60 @@ function MatchingOrganizerQuestionController({ }) {
             <EndQuestionButton />
         </div>
     )
+}
+
+
+
+function MatchingRunningOrder({ gameStates, lang = DEFAULT_LOCALE }) {
+    const game = useGameContext()
+
+    const [teams, teamsLoading, teamsError] = useCollection(collection(GAMES_COLLECTION_REF, game.id, 'teams'))
+    const [questionRealtimeData, questionRealtimeLoading, questionRealtimeError] = useDocumentData(doc(GAMES_COLLECTION_REF, game.id, 'rounds', game.currentRound, 'questions', game.currentQuestion))
+    if (questionRealtimeError) {
+        return <p><strong>Error: {JSON.stringify(questionRealtimeError)}</strong></p>
+    }
+    if (teamsError) {
+        return <p><strong>Error: {JSON.stringify(teamsError)}</strong></p>
+    }
+    if (questionRealtimeLoading || teamsLoading) {
+        return <></>
+    }
+    if (!questionRealtimeData || !teams) {
+        return <></>
+    }
+
+    const { canceled, teamNumMistakes } = questionRealtimeData
+    const canceledSet = new Set(canceled)
+
+    const { chooserOrder, chooserIdx } = gameStates
+
+    return (
+        <div className='flex flex-col h-full w-full items-center justify-center'>
+
+            <h2 className='2xl:text-xl 2xl:text-2xl font-bold'>👥 <span className='underline'>{RUNNING_ORDER_TEXT[lang]}</span></h2>
+
+            <ol className='overflow-auto'>
+                {chooserOrder.map((teamId, idx) => {
+                    const isCanceled = canceledSet.has(teamId)
+                    return <li key={idx} className={clsx(
+                        'xl:text-xl 2xl:text-2xl',
+                        idx === chooserIdx && 'text-focus',
+                        isCanceled && 'line-through opacity-25'
+                    )}>
+                        {idx + 1}. {getTeamName(teams, teamId)} {(teamId in teamNumMistakes) && `(${teamNumMistakes[teamId]})`}
+                    </li>
+                })}
+            </ol>
+        </div>
+    )
+}
+
+function getTeamName(teams, teamId) {
+    return teams.docs.find(doc => doc.id === teamId).data().name
+    // return teams.find(team => team.id === teamId).name
+}
+
+const RUNNING_ORDER_TEXT = {
+    'en': "Running order",
+    'fr-FR': "Ordre de passage"
 }

--- a/src/app/(game)/[id]/components/bottom-pane/question/question-active/riddle/players/RiddlePlayers.js
+++ b/src/app/(game)/[id]/components/bottom-pane/question/question-active/riddle/players/RiddlePlayers.js
@@ -81,7 +81,7 @@ function CanceledPlayers({ canceled, players }) {
     return (
         <ol className='overflow-auto'>
             {canceled.map((item, index) => (
-                <li key={index} className='2xl:text-xl'>💩 {getPlayerName(players, item.playerId)} {item.clueIdx && `(#${item.clueIdx + 1})`}</li>
+                <li key={index} className='2xl:text-xl'>💩 {getPlayerName(players, item.playerId)} {item.clueIdx >= 0 && `(#${item.clueIdx + 1})`}</li>
             ))}
         </ol>
     )

--- a/src/app/(game)/[id]/components/middle-pane/round/round-start/RoundCompletionRatePolicy.js
+++ b/src/app/(game)/[id]/components/middle-pane/round/round-start/RoundCompletionRatePolicy.js
@@ -5,15 +5,7 @@ export function RoundCompletionRatePolicy({ round }) {
         <div className='flex flex-col items-center justify-start space-y-4 p-2'>
             <RoundCompletionRatePolicyTitle round={round} />
             <div className='flex flex-col items-center justify-start'>
-                <p className='2xl:text-2xl'>Le barème</p>
-                <ol className='2xl:text-2xl border-solid border-yellow-500 border-2 p-2'>
-                    {round.rewards.map((reward, index) => (
-                        <li key={index}>{rankingToEmoji(index)} {reward} pts</li>
-                    ))}
-                    {/* <li key={round.rewards.length - 1}>...  0 pts</li> */}
-                </ol>
-                <br></br>
-                <p className='2xl:text-2xl text-center'>où les équipes sont classées dans l&apos;ordre <strong>{(round.type === 'odd_one_out' || round.type === 'matching') ? "⚠️ croissant" : "décroissant"}</strong> du nombre de points gagnés.</p>
+                <RoundMaxNumPoints round={round} />
             </div>
         </div>
     )
@@ -25,28 +17,74 @@ function RoundCompletionRatePolicyTitle({ round }) {
         case 'image':
         case 'blindtest':
         case 'emoji':
-        case 'basic':
         case 'enum':
+        case 'basic':
+            return <RiddleRoundCompletionRatePolicyTitle round={round} />
         case 'quote':
-        case 'mcq':
-            return <RoundMaxNumPoints round={round} />
+            return <QuoteRoundCompletionRatePolicyTitle round={round} />
         case 'odd_one_out':
+            return <OddOneOutRoundCompletionRatePolicyTitle round={round} />
         case 'matching':
             return <MatchingRoundCompletionRatePolicyTitle round={round} />
+        case 'mcq':
+            return <MCQRoundCompletionRatePolicyTitle round={round} />
         default:
             return <></>
     }
 }
 
 function RoundMaxNumPoints({ round }) {
-    const { maxPoints } = round
-    return <h1 className='2xl:text-3xl'>MAX <span className='font-bold'>{numberToKeycapEmoji(maxPoints)} points</span></h1>
+    switch (round.type) {
+        case 'progressive_clues':
+        case 'image':
+        case 'blindtest':
+        case 'emoji':
+        case 'enum':
+        case 'basic':
+        case 'quote':
+        case 'mcq':
+            const { maxPoints } = round
+            return <h1 className='2xl:text-3xl text-center'>Points max / équipe: <span className='font-bold'>{numberToKeycapEmoji(maxPoints)}</span></h1>
+        default:
+            return <></>
+    }
+
 }
 
+
+function RiddleRoundCompletionRatePolicyTitle({ round }) {
+    return <h1 className='2xl:text-3xl text-center'>✨ <span className='text-center text-green-500'><strong>{round.rewardsPerQuestion} point</strong> par bonne réponse</span> </h1>
+}
+
+function QuoteRoundCompletionRatePolicyTitle({ round }) {
+    return <h1 className='2xl:text-3xl text-center'>✨ <span className='text-center text-green-500'><strong>{round.rewardsPerElement} point</strong> par bon élément trouvé</span></h1>
+}
+
+function OddOneOutRoundCompletionRatePolicyTitle({ round }) {
+    const { mistakePenalty } = round
+    const absPenalty = Math.abs(mistakePenalty)
+    return <h1 className='2xl:text-2xl text-center'>✨ Sélectionner un intrus = <span className='text-red-500'><strong>{mistakePenalty} point{absPenalty > 1 ? 's' : ''}</strong> sur le score global</span></h1>
+}
 
 function MatchingRoundCompletionRatePolicyTitle({ round }) {
     const { mistakePenalty } = round
-    return <h1 className='2xl:text-3xl'><span className='font-bold'>{round.mistakePenalty} point</span> par mauvais lien créé</h1>
+    const absPenalty = Math.abs(mistakePenalty)
+    return <h1 className='2xl:text-2xl text-center'>✨ Dessiner un lien incorrect = <span className='text-red-500'><strong>{mistakePenalty} point{absPenalty > 1 ? 's' : ''}</strong> sur le score global</span></h1>
 }
 
+function MCQRoundCompletionRatePolicyTitle({ }) {
+    return <>
+        <h1 className='2xl:text-3xl text-center'>✨ Un nombre variable de points par bonne réponse</h1>
+    </>
+}
 
+function SpecialRoundCompletionRatePolicy({ round }) {
+    return (
+        <div className='flex flex-col items-center justify-start space-y-4'>
+            <h1 className='2xl:text-3xl text-center'>😨 Vos <strong>points accumulés</strong> jusqu&apos;à présent = votre <strong>nombre de droits à l&apos;erreur</strong></h1>
+            <div className='flex flex-col items-center justify-start'>
+                <p className='2xl:text-2xl text-center'>L&apos;ordre de passage = {round.order > 0 ? `Le classement inversé de la manche ${round.order}` : 'Un ordre aléatoire'}.</p>
+            </div>
+        </div>
+    )
+}

--- a/src/app/(game)/[id]/components/middle-pane/round/round-start/RoundCompletionRatePolicy.js
+++ b/src/app/(game)/[id]/components/middle-pane/round/round-start/RoundCompletionRatePolicy.js
@@ -1,0 +1,52 @@
+import { rankingToEmoji, numberToKeycapEmoji } from '@/lib/utils/emojis'
+
+export function RoundCompletionRatePolicy({ round }) {
+    return (
+        <div className='flex flex-col items-center justify-start space-y-4 p-2'>
+            <RoundCompletionRatePolicyTitle round={round} />
+            <div className='flex flex-col items-center justify-start'>
+                <p className='2xl:text-2xl'>Le barème</p>
+                <ol className='2xl:text-2xl border-solid border-yellow-500 border-2 p-2'>
+                    {round.rewards.map((reward, index) => (
+                        <li key={index}>{rankingToEmoji(index)} {reward} pts</li>
+                    ))}
+                    {/* <li key={round.rewards.length - 1}>...  0 pts</li> */}
+                </ol>
+                <br></br>
+                <p className='2xl:text-2xl text-center'>où les équipes sont classées dans l&apos;ordre <strong>{(round.type === 'odd_one_out' || round.type === 'matching') ? "⚠️ croissant" : "décroissant"}</strong> du nombre de points gagnés.</p>
+            </div>
+        </div>
+    )
+}
+
+function RoundCompletionRatePolicyTitle({ round }) {
+    switch (round.type) {
+        case 'progressive_clues':
+        case 'image':
+        case 'blindtest':
+        case 'emoji':
+        case 'basic':
+        case 'enum':
+        case 'quote':
+        case 'mcq':
+            return <RoundMaxNumPoints round={round} />
+        case 'odd_one_out':
+        case 'matching':
+            return <MatchingRoundCompletionRatePolicyTitle round={round} />
+        default:
+            return <></>
+    }
+}
+
+function RoundMaxNumPoints({ round }) {
+    const { maxPoints } = round
+    return <h1 className='2xl:text-3xl'>MAX <span className='font-bold'>{numberToKeycapEmoji(maxPoints)} points</span></h1>
+}
+
+
+function MatchingRoundCompletionRatePolicyTitle({ round }) {
+    const { mistakePenalty } = round
+    return <h1 className='2xl:text-3xl'><span className='font-bold'>{round.mistakePenalty} point</span> par mauvais lien créé</h1>
+}
+
+

--- a/src/app/(game)/[id]/components/middle-pane/round/round-start/RoundRankingPolicy.js
+++ b/src/app/(game)/[id]/components/middle-pane/round/round-start/RoundRankingPolicy.js
@@ -1,12 +1,12 @@
 import { rankingToEmoji, numberToKeycapEmoji } from '@/lib/utils/emojis'
 
-export function RoundRewards({ round }) {
+export function RoundRankingPolicy({ round }) {
     switch (round.type) {
         case 'special':
-            return <ThemesRoundRewards round={round} />
+            return <SpecialRoundRankingPolicy round={round} />
         default: return (
             <div className='flex flex-col items-center justify-start space-y-4 p-2'>
-                <RoundRewardsTitle round={round} />
+                <RoundRankingPolicyTitle round={round} />
                 <div className='flex flex-col items-center justify-start'>
                     <p className='2xl:text-2xl'>Le barème</p>
                     <ol className='2xl:text-2xl border-solid border-yellow-500 border-2 p-2'>
@@ -23,7 +23,7 @@ export function RoundRewards({ round }) {
     }
 }
 
-function RoundRewardsTitle({ round }) {
+function RoundRankingPolicyTitle({ round }) {
     switch (round.type) {
         case 'progressive_clues':
         case 'image':
@@ -31,43 +31,43 @@ function RoundRewardsTitle({ round }) {
         case 'emoji':
         case 'enum':
         case 'basic':
-            return <RiddleRoundRewardsTitle round={round} />
+            return <RiddleRoundRankingPolicyTitle round={round} />
         case 'quote':
-            return <QuoteRoundRewardsTitle round={round} />
+            return <QuoteRoundRankingPolicyTitle round={round} />
         case 'odd_one_out':
-            return <OddOneOutRoundRewardsTitle round={round} />
+            return <OddOneOutRoundRankingPolicyTitle round={round} />
         case 'matching':
-            return <MatchingRoundRewardsTitle round={round} />
+            return <MatchingRoundRankingPolicyTitle round={round} />
         case 'mcq':
-            return <MCQRoundRewardsTitle round={round} />
+            return <MCQRoundRankingPolicyTitle round={round} />
         default:
             return <></>
     }
 }
 
-function RiddleRoundRewardsTitle({ round }) {
+function RiddleRoundRankingPolicyTitle({ round }) {
     return <h1 className='2xl:text-3xl'><span className='font-bold'>{round.rewardsPerQuestion} point</span> par bonne réponse</h1>
 }
 
-function QuoteRoundRewardsTitle({ round }) {
+function QuoteRoundRankingPolicyTitle({ round }) {
     return <h1 className='2xl:text-3xl'><span className='font-bold'>{round.rewardsPerElement} point</span> par bon élément trouvé</h1>
 }
 
-function OddOneOutRoundRewardsTitle({ round }) {
+function OddOneOutRoundRankingPolicyTitle({ round }) {
     return <h1 className='2xl:text-3xl'><span className='font-bold'>{round.mistakePenalty} point</span> par intrus trouvé</h1>
 }
 
-function MatchingRoundRewardsTitle({ round }) {
+function MatchingRoundRankingPolicyTitle({ round }) {
     return <h1 className='2xl:text-3xl'><span className='font-bold'>{round.mistakePenalty} point</span> par mauvais lien créé</h1>
 }
 
-function MCQRoundRewardsTitle({ round }) {
+function MCQRoundRankingPolicyTitle({ round }) {
     return <>
         <h1 className='2xl:text-3xl text-center'>Un nombre variable de points par bonne réponse</h1>
     </>
 }
 
-function ThemesRoundRewards({ round }) {
+function SpecialRoundRankingPolicy({ round }) {
     return (
         <div className='flex flex-col items-center justify-start space-y-4'>
             <h1 className='2xl:text-3xl text-center'>😨 Vos <strong>points accumulés</strong> jusqu&apos;à présent = votre <strong>nombre de droits à l&apos;erreur</strong></h1>

--- a/src/app/(game)/[id]/components/middle-pane/round/round-start/RoundRankingPolicy.js
+++ b/src/app/(game)/[id]/components/middle-pane/round/round-start/RoundRankingPolicy.js
@@ -54,11 +54,13 @@ function QuoteRoundRankingPolicyTitle({ round }) {
 }
 
 function OddOneOutRoundRankingPolicyTitle({ round }) {
-    return <h1 className='2xl:text-3xl'><span className='font-bold'>{round.mistakePenalty} point</span> par intrus trouvé</h1>
+    const { mistakePenalty } = round
+    return <h1 className='2xl:text-3xl'><span className='font-bold'>{mistakePenalty} point{Math.abs(mistakePenalty) > 1 ? 's' : ''}</span> par intrus trouvé</h1>
 }
 
 function MatchingRoundRankingPolicyTitle({ round }) {
-    return <h1 className='2xl:text-3xl'><span className='font-bold'>{round.mistakePenalty} point</span> par mauvais lien créé</h1>
+    const { mistakePenalty } = round
+    return <h1 className='2xl:text-3xl'><span className='font-bold'>{mistakePenalty} point{Math.abs(mistakePenalty) > 1 ? 's' : ''}</span> par mauvais lien créé</h1>
 }
 
 function MCQRoundRankingPolicyTitle({ round }) {

--- a/src/app/(game)/[id]/components/middle-pane/round/round-start/RoundRules.js
+++ b/src/app/(game)/[id]/components/middle-pane/round/round-start/RoundRules.js
@@ -31,7 +31,7 @@ export function RoundRules({ round }) {
         case 'basic':
             return <BasicRoundRules round={round} />
         case 'special':
-            return <ThemesRoundRules round={round} />
+            return <SpecialRoundRules round={round} />
         case 'mixed':
             return <MixedRoundRules round={round} />
     }
@@ -106,15 +106,17 @@ function QuoteRoundRules({ round }) {
 
 
 function OddOneOutRoundRules({ round }) {
+    const { order, mistakePenalty } = round
+
     return <>
         <p className='2xl:text-2xl text-center'>🖱️ Chaque équipe se relaie à son tour et <strong>clique sur une proposition de la liste qu&apos;elle considère juste</strong>.</p>
         <ul className='2xl:text-2xl list-disc pl-10'>
             <li>Si la proposition est <span className='text-green-500 font-bold'>correcte</span>, on passe à l&apos;équipe suivante.</li>
-            <li>Si la proposition est <span className='text-red-500 font-bold'>incorrecte</span>, on termine la question et l&apos;équipe obtient <strong>{round.mistakePenalty} point de pénalité.</strong> De plus, elle devient <strong>1ère dans l&apos;ordre de passage de la question suivante</strong>.</li>
+            <li>Si la proposition est <span className='text-red-500 font-bold'>incorrecte</span>, on termine la question et l&apos;équipe obtient <strong>{mistakePenalty} point{Math.abs(mistakePenalty) > 1 ? 's' : ''} de pénalité.</strong> De plus, elle devient <strong>1ère dans l&apos;ordre de passage de la question suivante</strong>.</li>
         </ul>
         <p className='2xl:text-2xl text-center'>ℹ️ Une petite <strong>explication</strong> est affichée à chaque fois.</p>
         <p className='2xl:text-2xl text-center'>⏳ Vous avez <u><strong>{OOO_THINKING_TIME} secondes</strong></u> pour vous décider, faute de quoi <strong>une proposition sera choisie aléatoirement dans la liste !</strong></p>
-        <p className='2xl:text-2xl text-center'>L&apos;ordre de passage = {round.order > 0 ? `Le classement inversé de la manche ${round.order}` : 'Un ordre aléatoire'}.</p>
+        <p className='2xl:text-2xl text-center'>L&apos;ordre de passage = {order > 0 ? `Le classement inversé de la manche ${order}` : 'Un ordre aléatoire'}.</p>
     </>
 }
 
@@ -134,16 +136,18 @@ function EnumRoundRules({ round }) {
 }
 
 function MatchingRoundRules({ round }) {
+    const { order, mistakePenalty, maxMistakes } = round
+
     return <>
         <p className='2xl:text-2xl text-center'>🖱️ Chaque équipe se relaie à son tour et <strong>clique sur les propositions </strong> du lien qu&apos;elle considère juste, <span className='font-bold underline'>de gauche à droite</span>.</p>
         <ul className='2xl:text-2xl list-disc pl-10'>
             <li>Si le lien est <span className='text-green-500 font-bold'>correct</span>, on passe à l&apos;équipe suivante.</li>
-            <li>Si le lien est <span className='text-red-500 font-bold'>incorrect</span>, l&apos;équipe obtient <strong>{round.mistakePenalty} point de pénalité.</strong></li>
+            <li>Si le lien est <span className='text-red-500 font-bold'>incorrect</span>, l&apos;équipe obtient <strong>{mistakePenalty} point{Math.abs(mistakePenalty) > 1 ? 's' : ''} de pénalité.</strong></li>
         </ul>
         <p className='2xl:text-2xl text-center'>⚠️ <strong>Dans tous les cas, le lien est dessiné !</strong></p>
-        <p className='2xl:text-2xl text-center'>🙅 L&apos;équipe est <strong>disqualifiée</strong> de la question au bout de <strong>{round.maxMistakes || MATCHING_MAX_NUM_MISTAKES} erreurs</strong>, et la question s&apos;arrête si toutes les équipes sont disqualifiées.</p>
+        <p className='2xl:text-2xl text-center'>🙅 L&apos;équipe est <strong>disqualifiée</strong> de la question au bout de <strong>{maxMistakes || MATCHING_MAX_NUM_MISTAKES} erreurs</strong>, et la question s&apos;arrête si toutes les équipes sont disqualifiées.</p>
         <p className='2xl:text-2xl text-center'>⏳ Vous avez <u><strong>entre {MATCHING_THINKING_TIME * (MATCHING_MIN_NUM_COLS - 1)} et {MATCHING_THINKING_TIME * (MATCHING_MAX_NUM_COLS - 1)} secondes</strong></u> pour vous décider, faute de quoi <strong>un lien aléatoire sera dessiné !</strong></p>
-        <p className='2xl:text-2xl text-center'>L&apos;ordre de passage = {round.order > 0 ? `Le classement inversé de la manche ${round.order}` : 'Un ordre aléatoire'}.</p>
+        <p className='2xl:text-2xl text-center'>L&apos;ordre de passage = {order > 0 ? `Le classement inversé de la manche ${order}` : 'Un ordre aléatoire'}.</p>
     </>
 }
 
@@ -171,7 +175,7 @@ function BasicRoundRules({ round }) {
 
 
 // Special
-function ThemesRoundRules({ round }) {
+function SpecialRoundRules({ round }) {
     return <>
         <p className='2xl:text-2xl text-center font-bold'>🗣️ Répondez directement aux questions, il n&apos;y a pas de proposition de réponses.</p>
         <p className='2xl:text-2xl text-center'>⚠️ Attention, il faut être précis dans sa réponse!</p>

--- a/src/app/(game)/[id]/components/middle-pane/round/round-start/RoundRules.js
+++ b/src/app/(game)/[id]/components/middle-pane/round/round-start/RoundRules.js
@@ -2,7 +2,7 @@ import { BASIC_QUESTION_THINKING_TIME } from "@/lib/utils/question/basic"
 import { BLINDTEST_THINKING_TIME } from "@/lib/utils/question/blindtest"
 import { EMOJI_THINKING_TIME } from "@/lib/utils/question/emoji"
 import { IMAGE_THINKING_TIME } from "@/lib/utils/question/image"
-import { MATCHING_MAX_NUM_COLS, MATCHING_MIN_NUM_COLS, MATCHING_THINKING_TIME } from "@/lib/utils/question/matching"
+import { MATCHING_MAX_NUM_COLS, MATCHING_MAX_NUM_MISTAKES, MATCHING_MIN_NUM_COLS, MATCHING_THINKING_TIME } from "@/lib/utils/question/matching"
 import { MCQ_OPTIONS, MCQ_OPTION_TO_ICON, mcqOptionToTitle } from "@/lib/utils/question/mcq"
 import { OOO_THINKING_TIME } from "@/lib/utils/question/odd_one_out"
 import { PROGRESSIVE_CLUES_THINKING_TIME } from "@/lib/utils/question/progressive_clues"
@@ -141,6 +141,7 @@ function MatchingRoundRules({ round }) {
             <li>Si le lien est <span className='text-red-500 font-bold'>incorrect</span>, l&apos;équipe obtient <strong>{round.mistakePenalty} point de pénalité.</strong></li>
         </ul>
         <p className='2xl:text-2xl text-center'>⚠️ <strong>Dans tous les cas, le lien est dessiné !</strong></p>
+        <p className='2xl:text-2xl text-center'>🙅 L&apos;équipe est <strong>disqualifiée</strong> de la question au bout de <strong>{round.maxMistakes || MATCHING_MAX_NUM_MISTAKES} erreurs</strong>, et la question s&apos;arrête si toutes les équipes sont disqualifiées.</p>
         <p className='2xl:text-2xl text-center'>⏳ Vous avez <u><strong>entre {MATCHING_THINKING_TIME * (MATCHING_MIN_NUM_COLS - 1)} et {MATCHING_THINKING_TIME * (MATCHING_MAX_NUM_COLS - 1)} secondes</strong></u> pour vous décider, faute de quoi <strong>un lien aléatoire sera dessiné !</strong></p>
         <p className='2xl:text-2xl text-center'>L&apos;ordre de passage = {round.order > 0 ? `Le classement inversé de la manche ${round.order}` : 'Un ordre aléatoire'}.</p>
     </>

--- a/src/app/(game)/[id]/components/middle-pane/round/round-start/RoundStartBody.js
+++ b/src/app/(game)/[id]/components/middle-pane/round/round-start/RoundStartBody.js
@@ -8,7 +8,8 @@ import { numberToKeycapEmoji } from '@/lib/utils/emojis'
 
 import { RoundDescription } from './RoundDescription'
 import { RoundRules } from './RoundRules'
-import { RoundRewards } from './RoundRewards'
+import { RoundRankingPolicy } from './RoundRankingPolicy'
+import { RoundCompletionRatePolicy } from './RoundCompletionRatePolicy'
 
 export default function RoundStartBody({ round }) {
     return (
@@ -29,7 +30,7 @@ export default function RoundStartBody({ round }) {
 
             {/* Scaling */}
             <div className='border-dashed border-4 p-2 w-[30%] h-full overflow-auto'>
-                <RoundRewards round={round} />
+                <RoundScorePolicy round={round} />
             </div>
         </div >
     )
@@ -53,4 +54,13 @@ function SpecialNumThemes({ round }) {
     const game = useGameContext()
     const [themes, themesLoading, themesError] = useCollection(collection(GAMES_COLLECTION_REF, game.id, 'rounds', game.currentRound, 'themes'))
     return <span>{(!themesError && !themesLoading && themes) ? numberToKeycapEmoji(themes.docs.length) : '???'}</span>
+}
+
+function RoundScorePolicy({ round }) {
+    const game = useGameContext()
+
+    return <>
+        {game.roundScorePolicy === 'ranking' && <RoundRankingPolicy round={round} />}
+        {game.roundScorePolicy && 'completion_rate' && <RoundCompletionRatePolicy round={round} />}
+    </>
 }

--- a/src/app/(game)/[id]/components/sidebar/progress/round/RoundQuestionsProgress.js
+++ b/src/app/(game)/[id]/components/sidebar/progress/round/RoundQuestionsProgress.js
@@ -121,7 +121,7 @@ export const RoundQuestionAccordion = memo(function RoundQuestionAccordion({ gam
     const showComplete = myRole === 'organizer' || (isCurrent && game.status === 'question_end') || hasEnded || (game.status === 'round_end')
 
     const winnerPlayerData = (questionType) => {
-        if (questionType === 'mcq' || questionType === 'basic') {
+        if (questionType === 'mcq') {
             if (!realtime.correct)
                 return null
             return players.find(player => player.id === realtime.playerId)
@@ -132,7 +132,7 @@ export const RoundQuestionAccordion = memo(function RoundQuestionAccordion({ gam
     }
 
     const winnerTeamData = (questionType) => {
-        if (questionType === 'mcq' || questionType === 'basic') {
+        if (questionType === 'mcq') {
             if (!realtime.correct)
                 return null
             return teams.find(team => team.id === realtime.teamId)

--- a/src/app/(game)/[id]/components/top-pane/TeamScore.js
+++ b/src/app/(game)/[id]/components/top-pane/TeamScore.js
@@ -1,6 +1,6 @@
 import { GAMES_COLLECTION_REF } from '@/lib/firebase/firestore'
 import { doc } from 'firebase/firestore'
-import { useDocumentData } from 'react-firebase-hooks/firestore'
+import { useDocument, useDocumentData, useDocumentDataOnce } from 'react-firebase-hooks/firestore'
 
 import { CircularProgress } from '@mui/material'
 import { useParams } from 'next/navigation'
@@ -8,31 +8,30 @@ import { useParams } from 'next/navigation'
 export default function TeamScore({ teamId }) {
     const { id: gameId } = useParams()
 
-    const [game, gameLoading, gameError] = useDocumentData(doc(GAMES_COLLECTION_REF, gameId))
+    const [gameDoc, gameLoading, gameError] = useDocument(doc(GAMES_COLLECTION_REF, gameId))
     if (gameError) {
         return <p><strong>Error:</strong> {JSON.stringify(gameError)}</p>
     }
     if (gameLoading) {
         return <CircularProgress />
     }
-    if (!game) {
+    if (!gameDoc) {
         return <></>
     }
 
+    const game = { id: gameId, ...gameDoc.data() }
+
     if (game.type === 'random') {
         return <TeamGameScore teamId={teamId} />
+    } else if (game.type === 'rounds') {
+        if (game.roundScorePolicy === 'completion_rate') {
+            return <CompletionRatePolicyTeamScore teamId={teamId} game={game} />
+        } else {
+            return <RankingPolicyTeamScore teamId={teamId} game={game} />
+        }
     }
 
-    switch (game.status) {
-        case 'build':
-        case 'game_start':
-        case 'game_home':
-        case 'game_end':
-        case 'special':
-            return <TeamGameScore teamId={teamId} />
-        default:
-            return <TeamRoundScore teamId={teamId} roundId={game.currentRound} />
-    }
+
 }
 
 function TeamGameScore({ teamId }) {
@@ -69,4 +68,70 @@ function TeamRoundScore({ teamId, roundId }) {
     }
 
     return <span className='2xl:text-3xl'>{(roundScores.scores && Object.keys(roundScores.scores).includes(teamId)) && roundScores.scores[teamId]}</span>
+}
+
+function RankingPolicyTeamScore({ teamId, game }) {
+    switch (game.status) {
+        case 'build':
+        case 'game_start':
+        case 'game_home':
+        case 'game_end':
+        case 'special':
+        case 'round_start':
+        case 'round_end':
+            return <TeamGameScore teamId={teamId} />
+        default:
+            return <TeamRoundScore teamId={teamId} roundId={game.currentRound} />
+    }
+}
+
+function CompletionRatePolicyTeamScore({ teamId, game }) {
+    switch (game.status) {
+        case 'build':
+        case 'game_start':
+        case 'game_home':
+        case 'game_end':
+        case 'special':
+        case 'round_start':
+        case 'round_end':
+            return <TeamGameScore teamId={teamId} />
+        case 'question_active':
+        case 'question_end':
+            return <CompletionRatePolicyTeamRoundActiveScore teamId={teamId} game={game} />
+        default:
+            return <TeamRoundScore teamId={teamId} roundId={game.currentRound} />
+    }
+
+}
+
+function CompletionRatePolicyTeamRoundActiveScore({ teamId, game }) {
+    const [round, roundLoading, roundError] = useDocumentData(doc(GAMES_COLLECTION_REF, game.id, 'rounds', game.currentRound))
+    if (roundError) {
+        return <p><strong>Error:</strong> {JSON.stringify(roundError)}</p>
+    }
+    if (roundLoading) {
+        return <CircularProgress />
+    }
+    if (!round) {
+        return <></>
+    }
+
+    console.log("Round.twpe", round.type)
+    switch (round.type) {
+        case 'mixed':
+        case 'progressive_clues':
+        case 'image':
+        case 'emoji':
+        case 'blindtest':
+        case 'quote':
+        case 'enum':
+        case 'mcq':
+        case 'basic':
+            return <TeamRoundScore teamId={teamId} roundId={game.currentRound} />
+        case 'odd_one_out':
+        case 'matching':
+            return <TeamGameScore teamId={teamId} />
+        default:
+            return <TeamGameScore teamId={teamId} />
+    }
 }

--- a/src/app/(game)/lib/question/matching.js
+++ b/src/app/(game)/lib/question/matching.js
@@ -21,12 +21,12 @@ import { switchNextChooserTransaction } from '@/app/(game)/lib/chooser'
 import { addSoundEffectTransaction, addWrongAnswerSoundToQueueTransaction } from '@/app/(game)/lib/sounds';
 import { getDocDataTransaction } from '@/app/(game)/lib/utils';
 import { endQuestionTransaction } from '@/app/(game)/lib/question';
-import { increaseRoundTeamScoreTransaction } from '@/app/(game)/lib/scores';
+import { decreaseGlobalTeamScoreTransaction, increaseRoundTeamScoreTransaction } from '@/app/(game)/lib/scores';
 
-import { findMostFrequentValueAndIndices, generateMatch } from '@/lib/utils/question/matching';
+import { findMostFrequentValueAndIndices, generateMatch, matchingTeamIsCanceled } from '@/lib/utils/question/matching';
 import { sortScores } from '@/lib/utils/scores';
 import { sortAscendingRoundScores } from '@/lib/utils/round';
-import { getNextCyclicIndex, shuffle } from '@/lib/utils/arrays';
+import { aggregateTiedTeams, findNextAvailableChooser, shuffle } from '@/lib/utils/arrays';
 
 
 export async function submitMatch(gameId, roundId, questionId, userId, edges, match) {
@@ -107,6 +107,7 @@ const submitMatchTransaction = async (
                 transaction.update(chooserDoc.ref, { status: 'correct' })
             }
 
+            // Log the match
             transaction.update(correctMatchesRef, {
                 correctMatches: arrayUnion({
                     matchIdx: rows[0],
@@ -117,10 +118,7 @@ const submitMatchTransaction = async (
             })
 
             const sortedUniqueRoundScores = sortScores(currentRoundScores, sortAscendingRoundScores('matching'));
-            const roundSortedTeams = sortedUniqueRoundScores.map(score => {
-                const teamsWithThisScore = Object.keys(currentRoundScores).filter(tid => currentRoundScores[tid] === score);
-                return { score, teams: teamsWithThisScore };
-            });
+            const roundSortedTeams = aggregateTiedTeams(sortedUniqueRoundScores, currentRoundScores);
             const newChooserOrder = roundSortedTeams.slice().reverse().flatMap(({ teams }) => shuffle(teams));
             transaction.update(gameStatesRef, {
                 chooserOrder: newChooserOrder,
@@ -128,14 +126,33 @@ const submitMatchTransaction = async (
 
             await addSoundEffectTransaction(transaction, gameId, 'zelda_secret_door')
             await endQuestionTransaction(transaction, gameId, roundId, questionId)
+
         } else {
             // Case 1.1: The matching is correct but not the last one
-            await switchNextChooserTransaction(transaction, gameId)
-            for (const chooserDoc of choosersSnapshot.docs) {
-                transaction.update(chooserDoc.ref, { status: 'correct' })
-            }
-            await addSoundEffectTransaction(transaction, gameId, 'OUI')
 
+            // Switch to the next competing team
+            const questionRealtimeRef = doc(GAMES_COLLECTION_REF, gameId, 'rounds', roundId, 'questions', questionId)
+            const questionRealtimeData = await getDocDataTransaction(transaction, questionRealtimeRef)
+            const { canceled } = questionRealtimeData
+            const { newChooserIdx, newChooserTeamId } = findNextAvailableChooser(chooserIdx, chooserOrder, canceled)
+            const newChoosersSnapshot = await getDocs(query(playersCollectionRef, where('teamId', '==', newChooserTeamId)))
+
+            transaction.update(gameStatesRef, {
+                chooserIdx: newChooserIdx
+            })
+
+            for (const newChooserDoc of newChoosersSnapshot.docs) {
+                transaction.update(newChooserDoc.ref, {
+                    status: 'focus'
+                })
+            }
+            if (newChooserTeamId !== teamId) {
+                for (const chooserDoc of choosersSnapshot.docs) {
+                    transaction.update(chooserDoc.ref, { status: 'correct' })
+                }
+            }
+
+            // Log the match
             transaction.update(correctMatchesRef, {
                 correctMatches: arrayUnion({
                     matchIdx: rows[0],
@@ -144,32 +161,56 @@ const submitMatchTransaction = async (
                     timestamp: Timestamp.now(),
                 })
             })
+
+            // Sound effect
+            await addSoundEffectTransaction(transaction, gameId, 'OUI')
         }
     } else {
         // Case 2: The matching is incorrect
+        const gameRef = doc(GAMES_COLLECTION_REF, gameId)
         const roundRef = doc(GAMES_COLLECTION_REF, gameId, 'rounds', roundId)
-        const roundData = await getDocDataTransaction(transaction, roundRef)
-        const { mistakePenalty: penalty } = roundData
-        await increaseRoundTeamScoreTransaction(transaction, gameId, roundId, questionId, teamId, penalty)
+        const questionRealtimeRef = doc(GAMES_COLLECTION_REF, gameId, 'rounds', roundId, 'questions', questionId)
+        const roundScoresRef = doc(GAMES_COLLECTION_REF, gameId, 'rounds', roundId, 'realtime', 'scores')
+        const [gameData, roundData, questionRealtimeData, roundScoresData] = await Promise.all([
+            getDocDataTransaction(transaction, gameRef),
+            getDocDataTransaction(transaction, roundRef),
+            getDocDataTransaction(transaction, questionRealtimeRef),
+            getDocDataTransaction(transaction, roundScoresRef)
+        ])
 
+        const { roundScorePolicy } = gameData
+        const { mistakePenalty: penalty } = roundData
+        const { teamNumMistakes, canceled } = questionRealtimeData
+
+        // Increase the number of mistakes of the team
+        const newTeamNumMistakes = { ...teamNumMistakes }
+        newTeamNumMistakes[teamId] = (teamNumMistakes[teamId] || 0) + 1
+
+        // If the team has reached the maximum number of mistakes, cancel it
+        const isCanceled = matchingTeamIsCanceled(teamId, newTeamNumMistakes, roundData.maxMistakes)
+        const newCanceled = isCanceled ? [...canceled, teamId] : canceled;
+
+        if (roundScorePolicy === 'ranking') {
+            // Increase the team's round score to 1
+            await increaseRoundTeamScoreTransaction(transaction, gameId, roundId, questionId, teamId, penalty)
+        }
+        else if (roundScorePolicy === 'completion_rate') {
+            // Decrease the team's global score by the penalty and increment the number of mistakes of the team in the round
+            await decreaseGlobalTeamScoreTransaction(transaction, gameId, roundId, questionId, penalty, teamId)
+        }
+
+        // Update the mistake and canceled information
+        transaction.update(questionRealtimeRef, {
+            teamNumMistakes: newTeamNumMistakes,
+            canceled: newCanceled
+        })
+
+        // Set the status of the current chooser team to 'wrong'
         for (const chooserDoc of choosersSnapshot.docs) {
             transaction.update(chooserDoc.ref, { status: 'wrong' })
         }
 
-        const newChooserIdx = getNextCyclicIndex(chooserIdx, chooserOrder.length)
-        transaction.update(gameStatesRef, {
-            chooserIdx: newChooserIdx
-        })
-        const newChooserTeamId = chooserOrder[newChooserIdx]
-        const newChoosersSnapshot = await getDocs(query(playersCollectionRef, where('teamId', '==', newChooserTeamId)))
-        for (const newChooserDoc of newChoosersSnapshot.docs) {
-            transaction.update(newChooserDoc.ref, {
-                status: 'focus'
-            })
-        }
-
-        await addWrongAnswerSoundToQueueTransaction(transaction, gameId)
-
+        // Log the match
         const numCols = rows.length
         if (numCols > 2) {
             const [colIndices, rowIdx] = findMostFrequentValueAndIndices(rows)
@@ -195,6 +236,42 @@ const submitMatchTransaction = async (
                 timestamp: Timestamp.now(),
             }),
         })
+
+        // Switch to the next competing team, or end the question if all teams have been canceled
+
+        if (newCanceled.length < chooserOrder.length) {
+            // There are still competing teams => Set focus to the next competing team
+
+            const { newChooserIdx, newChooserTeamId } = findNextAvailableChooser(chooserIdx, chooserOrder, newCanceled)
+            const newChoosersSnapshot = await getDocs(query(playersCollectionRef, where('teamId', '==', newChooserTeamId)))
+
+            transaction.update(gameStatesRef, {
+                chooserIdx: newChooserIdx
+            })
+            for (const newChooserDoc of newChoosersSnapshot.docs) {
+                transaction.update(newChooserDoc.ref, {
+                    status: 'focus'
+                })
+            }
+
+            await addWrongAnswerSoundToQueueTransaction(transaction, gameId)
+
+        } else {
+            // All teams have been canceled => End the question
+
+            const { scores: currentRoundScores } = roundScoresData
+            const sortedUniqueRoundScores = sortScores(currentRoundScores, sortAscendingRoundScores('matching'));
+            const roundSortedTeams = aggregateTiedTeams(sortedUniqueRoundScores, currentRoundScores);
+            const newChooserOrder = roundSortedTeams.slice().reverse().flatMap(({ teams }) => shuffle(teams));
+            transaction.update(gameStatesRef, {
+                chooserOrder: newChooserOrder,
+            })
+
+            await addSoundEffectTransaction(transaction, gameId, 'zelda_wind_waker_sploosh')
+
+            await endQuestionTransaction(transaction, gameId, roundId, questionId)
+        }
+
     }
     // await updateTimerStateTransaction(transaction, gameId, 'reset')
 }
@@ -253,6 +330,12 @@ export async function resetMatchingQuestion(gameId, roundId, questionId) {
         chooserIdx: 0,
     })
 
+    const questionRealtimeRef = doc(GAMES_COLLECTION_REF, gameId, 'rounds', roundId, 'questions', questionId)
+    batch.update(questionRealtimeRef, {
+        teamNumMistakes: {},
+        canceled: [],
+    })
+
     const correctMatchesRef = doc(GAMES_COLLECTION_REF, gameId, 'rounds', roundId, 'questions', questionId, 'realtime', 'correct')
     batch.set(correctMatchesRef, {
         correctMatches: [],
@@ -275,6 +358,12 @@ export const resetMatchingQuestionTransaction = async (transaction, gameId, roun
     const gameStatesRef = doc(GAMES_COLLECTION_REF, gameId, 'realtime', 'states')
     transaction.update(gameStatesRef, {
         chooserIdx: 0,
+    })
+
+    const questionRealtimeRef = doc(GAMES_COLLECTION_REF, gameId, 'rounds', roundId, 'questions', questionId)
+    transaction.update(questionRealtimeRef, {
+        teamNumMistakes: {},
+        canceled: [],
     })
 
     const correctMatchesRef = doc(GAMES_COLLECTION_REF, gameId, 'rounds', roundId, 'questions', questionId, 'realtime', 'correct')

--- a/src/app/(game)/lib/question/mcq.js
+++ b/src/app/(game)/lib/question/mcq.js
@@ -1,6 +1,6 @@
 "use server";
 
-import { IMMEDIATE_MCQ_DEFAULT_REWARD, MCQ_CHOICES, MCQ_OPTIONS, CONDITIONAL_MCQ_OPTION_TO_SOUND } from '@/lib/utils/question/mcq';
+import { MCQ_CHOICES, MCQ_OPTIONS, CONDITIONAL_MCQ_OPTION_TO_SOUND } from '@/lib/utils/question/mcq';
 
 import { GAMES_COLLECTION_REF, QUESTIONS_COLLECTION_REF } from '@/lib/firebase/firestore';
 import { firestore } from '@/lib/firebase/firebase'
@@ -127,7 +127,7 @@ const selectMCQChoiceTransaction = async (
 
     const { subtype, answerIdx } = questionData.details
     const correct = choiceIdx === answerIdx
-    const reward = subtype === 'immediate' ? (correct ? IMMEDIATE_MCQ_DEFAULT_REWARD : 0) :
+    const reward = subtype === 'immediate' ? (correct ? roundData.rewardsPerQuestion : 0) :
         subtype === 'conditional' && correct ? roundData.rewardsPerQuestion[questionRealtimeData.option] : 0;
     await increaseRoundTeamScoreTransaction(transaction, gameId, roundId, questionId, teamId, reward)
 

--- a/src/app/(game)/lib/question/progressive_clues.js
+++ b/src/app/(game)/lib/question/progressive_clues.js
@@ -68,14 +68,16 @@ const revealProgressiveClueTransaction = async (
     })
 
     // Decancel players who need it
-    if (canceled && canceled.length > 0) {
-        const targetClueIdx = (questionRealtimeData.currentClueIdx + 1) - roundData.delay
-        for (const cancellation of canceled) {
-            if (cancellation.clueIdx === targetClueIdx) {
-                const playerRef = doc(GAMES_COLLECTION_REF, gameId, 'players', cancellation.playerId)
-                transaction.update(playerRef, { status: 'idle' })
-            }
-        }
+    if (canceled?.length > 0) {
+        const targetClueIdx = questionRealtimeData.currentClueIdx + 1 - roundData.delay
+        canceled
+            .filter(cancellation => cancellation.clueIdx === targetClueIdx)
+            .forEach(cancellation => {
+                const playerRef = doc(GAMES_COLLECTION_REF, gameId, 'players', cancellation.playerId);
+                transaction.update(playerRef, {
+                    status: 'idle'
+                });
+            });
     }
     // await updateTimerStateTransaction(transaction, gameId, 'reset')
     await addSoundEffectTransaction(transaction, gameId, 'cartoon_mystery_musical_tone_002')

--- a/src/app/(game)/lib/round/round-transitions.js
+++ b/src/app/(game)/lib/round/round-transitions.js
@@ -108,7 +108,7 @@ const selectRoundTransaction = async (
                 maxPoints = totalNumElements * rewardsPerElement;
                 break;
             case 'mcq':
-                maxPoints = Math.ceil(numQuestions / numTeams) * rewardsPerQuestion;
+                maxPoints = Math.ceil(numQuestions / numTeams) * rewardsPerQuestion['hide'];
                 break;
         }
     }

--- a/src/app/(game)/lib/round/round-transitions.js
+++ b/src/app/(game)/lib/round/round-transitions.js
@@ -13,7 +13,7 @@ import {
     limit,
 } from 'firebase/firestore'
 
-import { getNextCyclicIndex, shuffle } from '@/lib/utils/arrays';
+import { aggregateTiedTeams, getNextCyclicIndex, shuffle } from '@/lib/utils/arrays';
 import { isRiddle } from '@/lib/utils/question_types';
 import { sortAscendingRoundScores } from '@/lib/utils/round';
 import { sortScores } from '@/lib/utils/scores';
@@ -67,20 +67,58 @@ const selectRoundTransaction = async (
         getDocDataTransaction(transaction, gameRef)
     ]);
 
+    const { type: roundType, questions: questionIds, rewardsPerQuestion, rewardsForBonus, rewardsPerElement } = roundData
+    const { roundScorePolicy, currentRound, currentQuestion } = gameData
+
+
     let prevOrder = -1
-    if (gameData.currentRound !== null) {
-        const prevRoundRef = doc(GAMES_COLLECTION_REF, gameId, 'rounds', gameData.currentRound)
-        const prevRoundData = await getDocDataTransaction(transaction, prevRoundRef)
+    if (currentRound !== null) {
+        const prevRoundData = await getDocDataTransaction(transaction, doc(GAMES_COLLECTION_REF, gameId, 'rounds', currentRound))
         prevOrder = prevRoundData.order
     }
     const newOrder = prevOrder + 1
 
-    if (roundData.dateStart && !roundData.dateEnd && gameData.currentQuestion) {
+    let maxPoints = null
+
+    if (roundScorePolicy === 'completion_rate') {
+        const numQuestions = questionIds.length
+
+        const teamsCollectionRef = collection(GAMES_COLLECTION_REF, gameId, 'teams')
+        const teamsSnapshot = await getDocs(query(teamsCollectionRef))
+        const numTeams = teamsSnapshot.docs.length
+
+        switch (roundType) {
+            case 'progressive_clues':
+            case 'image':
+            case 'blindtest':
+            case 'emoji':
+            case 'basic':
+            case 'mixed':
+                maxPoints = numQuestions * rewardsPerQuestion;
+                break;
+            case 'enum':
+                maxPoints = numQuestions * (rewardsPerQuestion + rewardsForBonus);
+                break;
+            case 'quote':
+                const questions = await Promise.all(questionIds.map(questionId => getDocDataTransaction(transaction, doc(QUESTIONS_COLLECTION_REF, questionId))));
+                // The total number of quote elements to guess in the round
+                const totalNumElements = questions.reduce((acc, { details: { toGuess, quoteParts } }) => {
+                    return acc + toGuess.length + (toGuess.includes('quote') ? quoteParts.length - 1 : 0);
+                }, 0);
+                maxPoints = totalNumElements * rewardsPerElement;
+                break;
+            case 'mcq':
+                maxPoints = Math.ceil(numQuestions / numTeams) * rewardsPerQuestion;
+                break;
+        }
+    }
+
+    if (roundData.dateStart && !roundData.dateEnd && currentQuestion) {
         await updateGameStatusTransaction(transaction, gameId, 'question_active')
         return
     }
 
-    if (isRiddle(roundData.type) || roundData.type === 'quote' || roundData.type === 'enum' || roundData.type === 'mixed') {
+    if (isRiddle(roundType) || roundType === 'quote' || roundType === 'enum' || roundType === 'mixed') {
         // Set the status of every player to 'idle'
         const playersCollectionRef = collection(GAMES_COLLECTION_REF, gameId, 'players')
         const playersSnapshot = await getDocs(query(playersCollectionRef))
@@ -91,8 +129,8 @@ const selectRoundTransaction = async (
             })
         }
     }
-    if (roundData.type === 'mcq' || roundData.type === 'basic') {
-        const shuffledQuestionIds = shuffle(roundData.questions)
+    if (roundType === 'mcq') {
+        const shuffledQuestionIds = shuffle(questionIds)
         transaction.update(roundRef, {
             questions: shuffledQuestionIds
         })
@@ -102,7 +140,8 @@ const selectRoundTransaction = async (
     transaction.update(roundRef, {
         dateStart: serverTimestamp(),
         order: newOrder,
-        ...(roundData.type !== 'special' ? { currentQuestionIdx: 0 } : {})
+        ...(roundType !== 'special' ? { currentQuestionIdx: 0 } : {}),
+        ...(maxPoints !== null && { maxPoints })
     })
 
     // If the round requires an order of chooser teams (e.g. OOO, MCQ) and it is the first round, find a random order for the chooser teams
@@ -381,32 +420,135 @@ const endRoundTransaction = async (
         getDocDataTransaction(transaction, roundScoresRef)
     ]);
 
+    const { roundScorePolicy } = gameData
     const { scores: currentGlobalScores, scoresProgress: currentGlobalScoresProgress } = gameScoresData;
     // currentGlobalScores:         {team1: globalScore1, team2: globalScore2, ...}
-    // currentGlobalScoresProgress: {team1: {round1: roundScore11, round2: roundScore21}, team2: {round1: roundScore12, round2:roundScore22}, ...}
-
-    const { rewards: roundRewards, questions } = roundData; // e.g., [3, 2, 1]
+    // currentGlobalScoresProgress: {
+    //                                  team1: {round1: global score accumulated at the end of round1, round2: global score accumulated at the end of round2}, 
+    //                                  team2: {round1: global score accumulated at the end of round1, round2:global score accumulated at the end of round2}, 
+    //                              ...}
+    const { questions: questionIds, type: roundType, rewardsPerQuestion, rewardsForBonus, rewardsPerElement, subtype } = roundData;
     const { scores: roundScores, scoresProgress: currentRoundScoresProgress } = roundScoresData; // {team1: roundScore1, team2: roundScore2, ...}
 
 
-    // Sort the UNIQUE scores according to the notion of "winner first" 
-    const sortedUniqueRoundScores = sortScores(roundScores, sortAscendingRoundScores(roundData.type));
-
-    // Sort the teams accordingly and assign a reward for each
+    let newChooserOrder;
+    let roundSortedTeams;
+    let roundCompletionRates = null;
     const updatedGlobalScores = { ...currentGlobalScores };
-    const roundSortedTeams = sortedUniqueRoundScores.map((score, index) => {
-        const teamsWithThisScore = Object.keys(roundScores).filter(teamId => roundScores[teamId] === score);
-        const reward = index < roundRewards.length ? roundRewards[index] : 0;
-        teamsWithThisScore.forEach(teamId => updatedGlobalScores[teamId] = (updatedGlobalScores[teamId] || 0) + reward);
-        return { score, reward, teams: teamsWithThisScore };
-    });
 
-    // Reconstruct the missing scores for each team
+    // Sort the scores obtained in this round according to the notion of "performance" in this round
+    // For most rounds, the most performant team is the one with the highest score, but on error-based rounds it is the opposite (e.g., odd one out, matching)
+    // Here we calculate the UNIQUE scores, i.e., we remove the duplicates which appear when several teams have the same score
+    // Result: sortedUniqueRoundScores = [score1, score2, ...]
+    const sortedUniqueRoundScores = sortScores(roundScores, sortAscendingRoundScores(roundType));
+
+
+    /* ================================ Update the global scores of each team according to their performance in this round ================================ */
+    if (roundScorePolicy === 'completion_rate') {
+        // Score policy: calculate the "completion rate" of each team w.r.t. the maximum number of points of the round
+        // This rate (min 0, max 100) is the score that is added to the global score of the team
+        // This policy better reflects the performance of each team in the round
+
+        // Aggregates teams that have obtained the same score in this round
+        // Result: roundSortedTeams = [{score: score1, teams: [teamId1, teamId2, ...]}, {score: score2, teams: [teamId3, teamId4, ...]}, ...]
+        roundSortedTeams = aggregateTiedTeams(sortedUniqueRoundScores, roundScores);
+
+        if (!['odd_one_out', 'matching', 'special'].includes(roundType)) {
+
+            // Add the calculated rates to the global scores of each team
+            const updateGlobalScores = (completionRates) => {
+                Object.keys(completionRates).forEach(teamId => {
+                    updatedGlobalScores[teamId] = (updatedGlobalScores[teamId] || 0) + completionRates[teamId];
+                });
+            };
+
+            if (roundType === 'mcq') {
+                const questionRealtimeDatas = await Promise.all(
+                    questionIds.map(questionId =>
+                        getDocDataTransaction(transaction, doc(GAMES_COLLECTION_REF, gameId, 'rounds', roundId, 'questions', questionId))
+                    )
+                );
+
+                // Aggregate team stats
+                const teamStats = questionRealtimeDatas.reduce((acc, { teamId, reward }) => {
+                    if (!acc[teamId]) {
+                        acc[teamId] = { sumRewards: 0, numQuestions: 0 };
+                    }
+                    acc[teamId].sumRewards += reward;
+                    acc[teamId].numQuestions += 1;
+                    return acc;
+                }, {});
+
+                // Calculate the completion rate (in %) of each team
+                roundCompletionRates = Object.entries(teamStats).reduce((acc, [teamId, { sumRewards, numQuestions }]) => {
+                    const maxPoints = subtype === 'immediate'
+                        ? numQuestions * rewardsPerQuestion
+                        : numQuestions * rewardsPerQuestion['hide'];
+
+                    acc[teamId] = maxPoints > 0 ? Math.round(100 * sumRewards / maxPoints) : 0;
+                    return acc;
+                }, {});
+
+                console.log(teamStats);
+
+                updateGlobalScores(roundCompletionRates);
+
+            }
+            else {
+                // Calculate the completion rate (in %) of each team
+                const calculateCompletionRates = (maxPoints) => {
+                    return Object.keys(roundScores).reduce((points, teamId) => {
+                        points[teamId] = maxPoints > 0 ? Math.round(100 * roundScores[teamId] / maxPoints) : 0;
+                        return points;
+                    }, {});
+                };
+
+                const { maxPoints } = roundData;
+                roundCompletionRates = calculateCompletionRates(maxPoints);
+                updateGlobalScores(roundCompletionRates);
+            }
+        }
+    } else if (roundScorePolicy === 'ranking') {
+        // Score policy: independently of the performance of each team in the round:
+        // - the most performant team(s) get(s) the highest reward
+        // - the second most performant team(s) get(s) the second highest reward, 
+        // - ... and so on 
+        // - If no reward is defined for a given position, the team(s) at this position get 0
+        // This reward is the score that is added to the global score of the team
+
+        // Array defining the reward-position pairs
+        const { rewards: roundRewards } = roundData; // e.g., [3, 2, 1]
+
+        // Aggregates teams with the same score in this round
+        // At the same time, assign the reward accordingly
+        // Result: roundSortedTeams = [{score: score1, reward: reward1, teams: [teamId1, teamId2, ...]}, {score: score2, reward: reward2, teams: [teamId3, teamId4, ...]},
+        roundSortedTeams = sortedUniqueRoundScores.map((score, index) => {
+            const tiedTeams = Object.keys(roundScores).filter(teamId => roundScores[teamId] === score);
+            const shuffledTiedTeams = shuffle(tiedTeams);
+            const reward = index < roundRewards.length ? roundRewards[index] : 0;
+            tiedTeams.forEach(teamId => updatedGlobalScores[teamId] = (updatedGlobalScores[teamId] || 0) + reward);
+            return { score, reward, teams: shuffledTiedTeams };
+        });
+
+    }
+
+    // The "running order" for the next round prioritizes teams in reverse order of their performance in the current round.
+    // The first team in the array - i.e., the least performant (or one of the least performant) - will choose the next round
+    // Result: newChooserOrder = [teamId1, teamId2, ...]
+    // Because the "tied teams" (i.e., teams with the same score) were shuffled, flattening the array implicitly randomizes the order of teams with the same score.
+    // For example, if "TeamA" and "TeamC" are the two least performant teams for this round, the new running order could be ["TeamA", "TeamC", "TeamB"] or ["TeamC", "TeamA", "TeamB"].
+    newChooserOrder = roundSortedTeams.slice().reverse().flatMap(({ teams }) => shuffle(teams));
+
+    /* ================================================ ROUND PROGRESS ================================================ */
+
+    // Fills the missing scores for each team in this round
+    // Indeed, a team may not have won any points in several questions
+    // Result: filledRoundProgress = {team1: {question1: score1, question2: score2, ...}, team2: {question1: score1, question2: score2, ...}, ...}
     let filledRoundProgress = {}
     Object.keys(roundScores).forEach(teamId => {
         const teamRoundProgress = currentRoundScoresProgress[teamId] || {};
         let teamScores = {};
-        for (const [idx, questionId] of questions.entries()) {
+        for (const [idx, questionId] of questionIds.entries()) {
             const scoreAtQuestion = teamRoundProgress[questionId] || null;
             if (scoreAtQuestion != null) {
                 teamScores[questionId] = scoreAtQuestion;
@@ -416,24 +558,36 @@ const endRoundTransaction = async (
                 teamScores[questionId] = 0;
                 continue;
             }
-            const previousQuestionId = questions[idx - 1];
+            const previousQuestionId = questionIds[idx - 1];
             teamScores[questionId] = teamScores[previousQuestionId];
         }
         filledRoundProgress[teamId] = teamScores;
     })
 
-    let teamsScoresSequences = {}
-    for (const [teamId, teamProgress] of Object.entries(filledRoundProgress)) {
-        teamsScoresSequences[teamId] = roundData.questions.map(questionId => teamProgress[questionId]);
-    }
+    // Derives the "sequence of scores" of each team in the round, which describes the points accumulated in the round, question by question
+    // This element is useful only for visualization purposes in the summary shown at the end of the round
+    // Result: teamsScoresSequences = {team1: [score1, score2, ...], team2: [score1, score2, ...], ...}
+    const teamsScoresSequences = Object.entries(filledRoundProgress).reduce((acc, [teamId, teamProgress]) => {
+        acc[teamId] = questionIds.map(questionId => teamProgress[questionId]);
+        return acc;
+    }, {});
 
+
+    /* ================================================ GLOBAL PROGRESS ================================================ */
+
+    // Sort the "global scores" accumulated so far in the overall game
+    // As the goal for each team is to accumulate the most points in the game, the most performant team(s) is/are the one(s) with the highest score
+    // Result: sortedUpdatedGameScores = [score1, score2, ...]
     const sortedUpdatedGameScores = sortScores(updatedGlobalScores, false);
+
+    // Aggregates teams that have accumulated the same global score 
     const gameSortedTeams = sortedUpdatedGameScores.map(score => {
-        const teamsWithThisScore = Object.keys(updatedGlobalScores).filter(teamId => updatedGlobalScores[teamId] === score);
-        return { score, teams: teamsWithThisScore };
+        const tiedTeams = Object.keys(updatedGlobalScores).filter(teamId => updatedGlobalScores[teamId] === score);
+        return { score, teams: tiedTeams };
     });
 
-    // Create a updatedGlobalScoresProgress object that is equal to currentProgress but with an entry whose key is round and value is updatedGlobalScores[teamId] for every teamId
+    // Updates the "progress" of global scores for each team by indicating the global score resulting from this round
+    // Result: updatedGlobalScoresProgress = {team1: {round1: global_score1, round2: global_score2, ...}, team2: {round1: global_score1, round2: global_score2, ...}, ...}
     const updatedGlobalScoresProgress = Object.keys(updatedGlobalScores).reduce((progress, teamId) => {
         progress[teamId] = {
             ...currentGlobalScoresProgress[teamId],
@@ -442,10 +596,10 @@ const endRoundTransaction = async (
         return progress;
     }, {});
 
-    // newChooserOrder array is the flattened array of the teams in roundSortedTeams, in reverse order
-    // slice() is used to create a copy of the roundSortedTeams array
-    const newChooserOrder = roundSortedTeams.slice().reverse().flatMap(({ teams }) => shuffle(teams));
 
+    // Since the previous round (if any), the ranking of the teams w.r.t. the accumulated global scores may have changed
+    // This element calculates the "ranking difference" of each team compared to the previous round, i.e., the difference in position in the ranking 
+    // This element is useful only for visualization purposes in the summary shown at the end of the round
     let rankingDiffs = null
     if (roundData.order > 0) {
         const roundsRef = collection(GAMES_COLLECTION_REF, gameId, 'rounds')
@@ -462,15 +616,18 @@ const endRoundTransaction = async (
         gameSortedTeams,
         rankingDiffs,
         scoresProgress: filledRoundProgress,
-        teamsScoresSequences
+        teamsScoresSequences,
+        ...(roundCompletionRates !== null && { roundCompletionRates })
     })
     transaction.update(gameScoresRef, {
         scores: updatedGlobalScores,
         scoresProgress: updatedGlobalScoresProgress,
     })
 
+    // If the round is not the last one, update the running order of teams for the next round
     if (roundData.order < gameData.rounds.length - 1) {
-        // Set focus on chooser players, Set idle on all non-chooser players
+        // The first team in the running order - the "chooser" team - chooses the next round, hence the status 'focus'
+        // All other teams are set to 'idle'
         const playersCollectionRef = collection(GAMES_COLLECTION_REF, gameId, 'players')
         for (const [idx, teamId] of newChooserOrder.entries()) {
             const playersSnapshot = await getDocs(query(playersCollectionRef, where('teamId', '==', teamId)))
@@ -487,12 +644,14 @@ const endRoundTransaction = async (
         })
     }
 
+
+    // Transition to the round summary "slide"
+
     const readyRef = doc(GAMES_COLLECTION_REF, gameId, 'realtime', 'ready')
     transaction.update(readyRef, {
         numReady: 0
     })
 
-    /* End the round */
     transaction.update(roundRef, {
         dateEnd: serverTimestamp(),
     })

--- a/src/app/components/scores/RoundScoreboard.js
+++ b/src/app/components/scores/RoundScoreboard.js
@@ -4,12 +4,31 @@ import { DEFAULT_LOCALE } from '@/lib/utils/locales';
 import { rankingToEmoji } from '@/lib/utils/emojis';
 
 import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper } from '@mui/material'
-import { HEAD_RANKING_TEXT, HEAD_REWARD_TEXT, HEAD_SCORE_TEXT, HEAD_TEAM_TEXT } from './scoreboardUtils';
+import { HEAD_RANKING_TEXT, HEAD_REWARD_TEXT, HEAD_COMPLETION_RATE_TEXT, HEAD_SCORE_TEXT, HEAD_TEAM_TEXT } from './scoreboardUtils';
 
 import clsx from 'clsx';
+import { useGameContext } from '@/app/(game)/contexts';
+import { useDocumentDataOnce } from 'react-firebase-hooks/firestore';
+import { doc } from 'firebase/firestore';
+import { GAMES_COLLECTION_REF } from '@/lib/firebase/firestore';
 
 export default function RoundScoreboard({ roundScores, teams, lang = DEFAULT_LOCALE }) {
-    const roundSortedTeams = roundScores.roundSortedTeams
+    const { roundSortedTeams } = roundScores
+    const game = useGameContext()
+
+    const [round, roundLoading, roundError] = useDocumentDataOnce(doc(GAMES_COLLECTION_REF, game.id, 'rounds', game.currentRound))
+    if (roundError) {
+        return <p><strong>Error: {JSON.stringify(roundError)}</strong></p>
+    }
+    if (roundLoading) {
+        return <p>Loading round...</p>
+    }
+    if (!round) {
+        return <></>
+    }
+
+    const completionRounds = ['progressive_clues', 'image', 'emoji', 'blindtest', 'quote', 'enum', 'mcq', 'basic', 'mixed']
+    const isCompletionRound = completionRounds.includes(round.type)
 
     return (
         <TableContainer component={Paper} className='w-2/3'>
@@ -20,7 +39,8 @@ export default function RoundScoreboard({ roundScores, teams, lang = DEFAULT_LOC
                         <TableCell className='2xl:text-2xl font-bold text-center'>{HEAD_RANKING_TEXT[lang]}</TableCell>
                         <TableCell className='2xl:text-2xl font-bold'>{HEAD_TEAM_TEXT[lang]}</TableCell>
                         <TableCell className='2xl:text-2xl font-bold text-center'>{HEAD_SCORE_TEXT[lang]}</TableCell>
-                        <TableCell className='2xl:text-2xl font-bold text-center'>{HEAD_REWARD_TEXT[lang]}</TableCell>
+                        {game.roundScorePolicy === 'ranking' && <TableCell className='2xl:text-2xl font-bold text-center'>{HEAD_REWARD_TEXT[lang]}</TableCell>}
+                        {game.roundScorePolicy === 'completion_rate' && isCompletionRound && <TableCell className='2xl:text-2xl font-bold text-center'>{HEAD_COMPLETION_RATE_TEXT[lang]}</TableCell>}
                     </TableRow>
                 </TableHead>
 
@@ -51,12 +71,20 @@ export default function RoundScoreboard({ roundScores, teams, lang = DEFAULT_LOC
                                         </TableCell>
 
                                         <TableCell className='2xl:text-2xl text-center font-bold'>
-                                            <span className={clsx(
-                                                hasEarnedPoints && 'text-green-500',
-                                                hasLostPoints && 'text-red-500',
-                                            )}>
-                                                {hasEarnedPoints && "+"}{item.reward}
-                                            </span>
+                                            {game.roundScorePolicy === 'ranking' &&
+                                                <span className={clsx(
+                                                    hasEarnedPoints && 'text-green-500',
+                                                    hasLostPoints && 'text-red-500',
+                                                )}>
+                                                    {hasEarnedPoints && "+"}{item.reward}
+                                                </span>
+                                            }
+                                            {game.roundScorePolicy === 'completion_rate' && isCompletionRound &&
+                                                <span>
+                                                    {roundScores.roundCompletionRates[teamId]}
+                                                </span>
+                                            }
+
                                         </TableCell>
                                     </TableRow>
                                 )

--- a/src/app/components/scores/scoreboardUtils.js
+++ b/src/app/components/scores/scoreboardUtils.js
@@ -17,3 +17,8 @@ export const HEAD_REWARD_TEXT = {
     'en': "Reward",
     'fr-FR': "Récompense"
 }
+
+export const HEAD_COMPLETION_RATE_TEXT = {
+    'en': "Completion (%)",
+    'fr-FR': "Complétion (%)"
+}

--- a/src/app/edit/[id]/lib/create-game.js
+++ b/src/app/edit/[id]/lib/create-game.js
@@ -14,10 +14,10 @@ import {
 
 
 /* ==================================================================================================== */
-export async function createGame(title, type, lang, maxPlayers, organizerName, organizerId) {
+export async function createGame(title, type, lang, maxPlayers, roundScorePolicy, organizerName, organizerId) {
     try {
         const gameId = await runTransaction(firestore, transaction =>
-            createGameTransaction(transaction, title, type, lang, maxPlayers, organizerName, organizerId)
+            createGameTransaction(transaction, title, type, lang, maxPlayers, roundScorePolicy, organizerName, organizerId)
         )
         console.log(`Game ${gameId} created successfully.`)
         return gameId;
@@ -33,6 +33,7 @@ export const createGameTransaction = async (
     type,
     lang,
     maxPlayers,
+    roundScorePolicy,
     organizerName,
     organizerId,
 ) => {
@@ -48,6 +49,7 @@ export const createGameTransaction = async (
         dateStart: null,
         lang,
         maxPlayers,
+        roundScorePolicy,
         status: 'build',
         title,
         type,

--- a/src/app/edit/[id]/lib/edit-game.js
+++ b/src/app/edit/[id]/lib/edit-game.js
@@ -4,8 +4,8 @@ import { BLINDTEST_DEFAULT_REWARD, BLINDTEST_DEFAULT_MAX_TRIES } from '@/lib/uti
 import { EMOJI_DEFAULT_REWARD, EMOJI_DEFAULT_MAX_TRIES } from '@/lib/utils/question/emoji';
 import { ENUM_DEFAULT_BONUS, ENUM_DEFAULT_REWARD } from '@/lib/utils/question/enum';
 import { IMAGE_DEFAULT_MAX_TRIES, IMAGE_DEFAULT_REWARD } from '@/lib/utils/question/image';
-import { MATCHING_DEFAULT_MISTAKE_PENALTY } from '@/lib/utils/question/matching';
-import { MCQ_DEFAULT_REWARDS } from '@/lib/utils/question/mcq';
+import { MATCHING_DEFAULT_MISTAKE_PENALTY, MATCHING_MAX_NUM_MISTAKES } from '@/lib/utils/question/matching';
+import { IMMEDIATE_MCQ_DEFAULT_REWARD, MCQ_DEFAULT_REWARDS as CONDITIONAL_MCQ_DEFAULT_REWARDS } from '@/lib/utils/question/mcq';
 import { OOO_DEFAULT_MISTAKE_PENALTY } from '@/lib/utils/question/odd_one_out';
 import { PROGRESSIVE_CLUES_DEFAULT_DELAY, PROGRESSIVE_CLUES_DEFAULT_MAX_TRIES, PROGRESSIVE_CLUES_DEFAULT_REWARD } from '@/lib/utils/question/progressive_clues';
 import { isRiddle } from '@/lib/utils/question_types';
@@ -67,43 +67,44 @@ const addGameRoundTransaction = async (
     }
 
     if (type === 'mixed') {
-        initRoundInfo.rewardsPerQuestion = 1
+        initRoundInfo.rewardsPerQuestion = 1;
         initRoundInfo.invalidateTeam = false;
-        initRoundInfo.maxTries = 2
-        initRoundInfo.delay = 2
+        initRoundInfo.maxTries = 2;
+        initRoundInfo.delay = 2;
         initRoundInfo.rewardsForBonus = 1;
-        initRoundInfo.mistakePenalty = - 1
-        initRoundInfo.rewardsPerElement = 1
+        initRoundInfo.mistakePenalty = - 1;
+        initRoundInfo.rewardsPerElement = 1;
     } else if (type === 'progressive_clues') {
-        initRoundInfo.rewardsPerQuestion = PROGRESSIVE_CLUES_DEFAULT_REWARD
+        initRoundInfo.rewardsPerQuestion = PROGRESSIVE_CLUES_DEFAULT_REWARD;
         initRoundInfo.invalidateTeam = false;
-        initRoundInfo.maxTries = PROGRESSIVE_CLUES_DEFAULT_MAX_TRIES
-        initRoundInfo.delay = PROGRESSIVE_CLUES_DEFAULT_DELAY
+        initRoundInfo.maxTries = PROGRESSIVE_CLUES_DEFAULT_MAX_TRIES;
+        initRoundInfo.delay = PROGRESSIVE_CLUES_DEFAULT_DELAY;
     } else if (type === 'image') {
-        initRoundInfo.rewardsPerQuestion = IMAGE_DEFAULT_REWARD
+        initRoundInfo.rewardsPerQuestion = IMAGE_DEFAULT_REWARD;
         initRoundInfo.invalidateTeam = false;
-        initRoundInfo.maxTries = IMAGE_DEFAULT_MAX_TRIES
+        initRoundInfo.maxTries = IMAGE_DEFAULT_MAX_TRIES;
     } else if (type === 'blindtest') {
-        initRoundInfo.rewardsPerQuestion = BLINDTEST_DEFAULT_REWARD
+        initRoundInfo.rewardsPerQuestion = BLINDTEST_DEFAULT_REWARD;
         initRoundInfo.invalidateTeam = false;
-        initRoundInfo.maxTries = BLINDTEST_DEFAULT_MAX_TRIES
+        initRoundInfo.maxTries = BLINDTEST_DEFAULT_MAX_TRIES;
     } else if (type === 'emoji') {
-        initRoundInfo.rewardsPerQuestion = EMOJI_DEFAULT_REWARD
+        initRoundInfo.rewardsPerQuestion = EMOJI_DEFAULT_REWARD;
         initRoundInfo.invalidateTeam = false;
-        initRoundInfo.maxTries = EMOJI_DEFAULT_MAX_TRIES
+        initRoundInfo.maxTries = EMOJI_DEFAULT_MAX_TRIES;
     } else if (type === 'quote') {
-        initRoundInfo.rewardsPerElement = QUOTE_DEFAULT_REWARDS_PER_ELEMENT
+        initRoundInfo.rewardsPerElement = QUOTE_DEFAULT_REWARDS_PER_ELEMENT;
         initRoundInfo.invalidateTeam = false;
-        initRoundInfo.maxTries = QUOTE_DEFAULT_MAX_TRIES
+        initRoundInfo.maxTries = QUOTE_DEFAULT_MAX_TRIES;
     } else if (type === 'enum') {
-        initRoundInfo.rewardsPerQuestion = ENUM_DEFAULT_REWARD
+        initRoundInfo.rewardsPerQuestion = ENUM_DEFAULT_REWARD;
         initRoundInfo.rewardsForBonus = ENUM_DEFAULT_BONUS;
     } else if (type === 'odd_one_out') {
-        initRoundInfo.mistakePenalty = OOO_DEFAULT_MISTAKE_PENALTY
+        initRoundInfo.mistakePenalty = OOO_DEFAULT_MISTAKE_PENALTY;
     } else if (type === 'matching') {
-        initRoundInfo.mistakePenalty = MATCHING_DEFAULT_MISTAKE_PENALTY
+        initRoundInfo.mistakePenalty = MATCHING_DEFAULT_MISTAKE_PENALTY;
+        initRoundInfo.maxMistakes = MATCHING_MAX_NUM_MISTAKES;
     } else if (type === 'mcq') {
-        initRoundInfo.rewardsPerQuestion = MCQ_DEFAULT_REWARDS
+        initRoundInfo.rewardsPerQuestion = CONDITIONAL_MCQ_DEFAULT_REWARDS;
     } else if (type === 'basic') {
         initRoundInfo.rewardsPerQuestion = BASIC_QUESTION_DEFAULT_REWARD;
     }
@@ -238,6 +239,8 @@ const addGameQuestionTransaction = async (
     } else if (questionData.type === 'matching') {
         transaction.set(questionRealtimeRef, {
             ...commonRealtimeInfo,
+            teamNumMistakes: {},
+            canceled: [],
         });
 
         // Create the document doc(GAMES_COLLECTION_REF, gameId, 'rounds', roundId, 'questions', questionId, 'realtime', 'correct')

--- a/src/app/edit/components/SelectRoundScorePolicy.js
+++ b/src/app/edit/components/SelectRoundScorePolicy.js
@@ -1,0 +1,27 @@
+import { MySelect } from '@/app/components/forms/StyledFormComponents'
+
+import { DEFAULT_LOCALE } from '@/lib/utils/locales';
+import { prependRoundScorePolicyWithEmoji, ROUND_SCORE_POLICIES } from '@/lib/utils/scores';
+
+export default function SelectRoundScorePolicy({ validationSchema, lang = DEFAULT_LOCALE, name = 'roundScorePolicy' }) {
+    return (
+        <MySelect
+            label={SELECT_SCORE_POLICY_LABEL[lang]}
+            name={name}
+            validationSchema={validationSchema}
+        >
+            <option value="">{SELECT_SCORE_POLICY_HEADER[lang]}</option>
+            {ROUND_SCORE_POLICIES.map((policy) => <option key={policy} value={policy}>{prependRoundScorePolicyWithEmoji(policy)}</option>)}
+        </MySelect>
+    )
+}
+
+const SELECT_SCORE_POLICY_LABEL = {
+    'en': "Round score policy",
+    'fr-FR': "Politique de score pour la manche"
+}
+
+const SELECT_SCORE_POLICY_HEADER = {
+    'en': "Select the round score policy",
+    'fr-FR': "Sélectionnez la politique de score pour la manche"
+}

--- a/src/app/edit/page.js
+++ b/src/app/edit/page.js
@@ -9,16 +9,18 @@ import SubmitFormButton from '@/app/components/forms/SubmitFormButton';
 
 import { DEFAULT_LOCALE, localeSchema } from '@/lib/utils/locales';
 import { stringSchema } from '@/lib/utils/forms';
+import { roundScorePolicySchema } from '@/lib/utils/scores';
 import { IMAGE_TITLE_MAX_LENGTH } from '@/lib/utils/question/image';
 
 import { useSession } from 'next-auth/react';
 import { redirect, useRouter } from 'next/navigation'
 
+import SelectGameType from '@/app/edit/components/SelectGameType';
+import SelectRoundScorePolicy from '@/app/edit/components/SelectRoundScorePolicy';
 import SelectLanguage from '@/app/submit/components/SelectLanguage';
 
 import { useAsyncAction } from '@/lib/utils/async';
 import { GAME_DEFAULT_TYPE, GAME_MAX_NUMBER_OF_PLAYERS, GAME_MIN_NUMBER_OF_PLAYERS, GAME_PARTICIPANT_NAME_MAX_LENGTH, GAME_TITLE_EXAMPLE, GAME_TITLE_MAX_LENGTH, gameTypeSchema } from '@/lib/utils/game';
-import SelectGameType from './components/SelectGameType';
 import { createGame } from './[id]/lib/create-game';
 
 export default function Page({ lang = DEFAULT_LOCALE }) {
@@ -26,8 +28,8 @@ export default function Page({ lang = DEFAULT_LOCALE }) {
     const router = useRouter()
 
     const [createNewGame, isSubmitting] = useAsyncAction(async (values, userId) => {
-        const { title, type, lang, maxPlayers, organizerName } = values;
-        const gameId = await createGame(title, type, lang, maxPlayers, organizerName, userId);
+        const { title, type, lang, maxPlayers, roundScorePolicy, organizerName } = values;
+        const gameId = await createGame(title, 'rounds', lang, maxPlayers, roundScorePolicy, organizerName, userId);
         router.push('/edit/' + gameId);
     });
 
@@ -42,9 +44,10 @@ export default function Page({ lang = DEFAULT_LOCALE }) {
 
     const validationSchema = Yup.object({
         lang: localeSchema(),
-        type: gameTypeSchema(),
+        // type: gameTypeSchema(),
         title: stringSchema(IMAGE_TITLE_MAX_LENGTH),
         maxPlayers: Yup.number().required().integer(),
+        roundScorePolicy: roundScorePolicySchema(),
         organizerName: stringSchema(GAME_PARTICIPANT_NAME_MAX_LENGTH),
         // imageFiles: imageFileSchema(fileRef),
     })
@@ -54,10 +57,11 @@ export default function Page({ lang = DEFAULT_LOCALE }) {
             <h1>{CREATE_GAME[lang]}</h1>
             <Formik
                 initialValues={{
-                    type: GAME_DEFAULT_TYPE,
+                    // type: GAME_DEFAULT_TYPE,
                     lang: DEFAULT_LOCALE,
                     title: '',
                     maxPlayers: GAME_MIN_NUMBER_OF_PLAYERS,
+                    roundScorePolicy: '',
                     organizerName: '',
                     // imageFiles: ''
 
@@ -75,7 +79,7 @@ export default function Page({ lang = DEFAULT_LOCALE }) {
                 <Form>
                     <SelectLanguage labels={SELECT_GAME_LANGUAGE_LABEL} lang={lang} name='lang' validationSchema={validationSchema} />
 
-                    <SelectGameType lang={lang} name='type' validationSchema={validationSchema} />
+                    {/* <SelectGameType lang={lang} name='type' validationSchema={validationSchema} /> */}
 
                     <MyTextInput
                         label={GAME_TITLE_LABEL[lang]}
@@ -92,6 +96,8 @@ export default function Page({ lang = DEFAULT_LOCALE }) {
                         min={GAME_MIN_NUMBER_OF_PLAYERS} max={GAME_MAX_NUMBER_OF_PLAYERS}
                     // validationSchema={validationSchema}
                     />
+
+                    <SelectRoundScorePolicy lang={lang} name='roundScorePolicy' validationSchema={validationSchema} />
 
                     <MyTextInput
                         label={GAME_ORGANIZER_NAME_LABEL[lang]}

--- a/src/lib/utils/arrays.js
+++ b/src/lib/utils/arrays.js
@@ -43,3 +43,25 @@ export function moveToHead(elem, array) {
 export function isEmpty(array) {
     return array.length === 0;
 }
+
+export function aggregateTiedTeams(uniqueScores, scores) {
+    return uniqueScores.slice().map(score => {
+        const tiedTeams = Object.keys(scores).filter(tid => scores[tid] === score);
+        const shuffledTiedTeams = shuffle(tiedTeams);
+        return { score, teams: shuffledTiedTeams };
+    });
+}
+
+export function findNextAvailableChooser(chooserIdx, chooserOrder, canceled) {
+    const canceledSet = new Set(canceled); // Convert canceled array to a Set for faster lookups
+
+    let newChooserIdx = chooserIdx
+    let newChooserTeamId = chooserOrder[chooserIdx]
+
+    do {
+        newChooserIdx = getNextCyclicIndex(newChooserIdx, chooserOrder.length)
+        newChooserTeamId = chooserOrder[newChooserIdx]
+    } while (canceledSet.has(newChooserTeamId))
+
+    return { newChooserIdx, newChooserTeamId };
+}

--- a/src/lib/utils/question/matching.js
+++ b/src/lib/utils/question/matching.js
@@ -43,9 +43,10 @@ export const MATCHING_MAX_NUM_ROWS = 10;
 export const MATCHING_ITEM_MAX_LENGTH = 30;
 
 export const MATCHING_DEFAULT_MISTAKE_PENALTY = 1;
-
+export const MATCHING_MAX_NUM_MISTAKES = 3;
 
 export const MATCHING_THINKING_TIME = 40
+
 
 /* In-game logic */
 export function shuffleMatching(numCols, numRows) {
@@ -125,4 +126,8 @@ export function edgesToString(edges, answer) {
     });
 
     return leftToRightPath.map(id => getNodeText(id, answer)).join(' - ')
+}
+
+export function matchingTeamIsCanceled(teamId, teamNumMistakes, maxMistakes) {
+    return teamId in teamNumMistakes && teamNumMistakes[teamId] >= maxMistakes;
 }

--- a/src/lib/utils/scores.js
+++ b/src/lib/utils/scores.js
@@ -1,2 +1,43 @@
 export const sortScores = (scores, ascending) =>
     [...new Set(Object.values(scores))].sort((a, b) => ascending ? a - b : b - a);
+
+export const ROUND_SCORE_POLICIES = ['ranking', 'completion_rate']
+
+export const ROUND_SCORE_POLICY_TO_TITLE = {
+    'en': {
+        'ranking': "Ranking in round",
+        'completion_rate': "Completion rate of round"
+    },
+    'fr-FR': {
+        'ranking': "Classement dans la manche",
+        'completion_rate': "Taux de complétion de la manche"
+    }
+}
+
+export const ROUND_SCORE_POLICY_TO_EMOJI = {
+    'ranking': "🏆",
+    'completion_rate': "💯"
+}
+
+import { DEFAULT_LOCALE } from './locales';
+
+export function roundScorePolicyToTitle(policy, locale = DEFAULT_LOCALE) {
+    return ROUND_SCORE_POLICY_TO_TITLE[locale][policy]
+}
+
+export function roundScorePolicyToEmoji(policy) {
+    return ROUND_SCORE_POLICY_TO_EMOJI[policy]
+}
+
+import { prependWithEmojiAndSpace } from '@/lib/utils/emojis';
+export function prependRoundScorePolicyWithEmoji(policy, lang = DEFAULT_LOCALE) {
+    return prependWithEmojiAndSpace(roundScorePolicyToEmoji(policy), roundScorePolicyToTitle(policy, lang))
+}
+
+
+/* Validation */
+import * as Yup from 'yup';
+
+export const roundScorePolicySchema = () => Yup.string()
+    .oneOf(ROUND_SCORE_POLICIES, "Invalid round score policy.")
+    .required("Required.")


### PR DESCRIPTION
- Add a differentiation between two round score policies: ranking-based and completion rate-based.
- Clean the code for updating the global scores and round scores, and recording the progress of both scores for each team